### PR TITLE
filtrere netteiere på konsesjonær

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ Den følgende listen viser status på innsamlede data.
 
 - [ ] Alut AS - 7080010004383
 - [ ] Arva AS - 7080005051859
-- [ ] Arva AS (tidligere Nordlandsnett) - 7080005051361
 - [ ] Asker Nett AS - 7080003858825
 - [ ] BKK AS - 7080005051378
 - [ ] Bindal Kraftlag Nett - 7080005055963
@@ -247,14 +246,11 @@ Den følgende listen viser status på innsamlede data.
 - [ ] Etna Nett AS - 7080005046404
 - [ ] Everket AS - 7080005052825
 - [ ] Fagne AS - 7080003809599
-- [ ] Fjellnett AS - 7080010000316
 - [ ] Føie AS - 7080005048415
 - [ ] Føre AS - 7080010003836
-- [ ] Glitre Nett AS (tidl Glitre Energi Nett, Distrib.) - 7080005052672
 - [ ] Glitre Nett AS (tidligere Agder Energi Nett) - 7080005056069
 - [ ] Griug AS - 7080005052900
 - [ ] Havnett AS - 7080010001832
-- [ ] Hydro Energi AS nett - 7080005052818
 - [ ] Høland og Setskog Elverk AS - 7080004320253
 - [ ] Indre Hordaland Kraftnett AS - 7080010008367
 - [ ] Jæren Everk AS - 7080010002419
@@ -265,7 +261,6 @@ Den følgende listen viser status på innsamlede data.
 - [ ] Lede AS - 7080005050975
 - [x] Linja AS - 7080001319830 - Sist oppdatert `2024-11-03`
 - [ ] Lucerna AS - 7080005050661
-- [ ] Lyse Produksjon AS Nett - 7080003307231
 - [ ] Lysna AS - 7080010013088
 - [ ] Meløy Nett AS - 7080003968395
 - [x] Midtnett AS - 7080003869012 - Sist oppdatert `2024-11-03`
@@ -280,7 +275,6 @@ Den følgende listen viser status på innsamlede data.
 - [ ] Romsdalsnett AS - 7080010005427
 - [ ] Røros E-verk Nett AS - 7080003947932
 - [ ] S-NETT AS - 7080010002464
-- [ ] SkiakerNett AS - 7080004062702
 - [ ] Stannum AS - 7080010003959
 - [ ] Stram AS - 7080003822901
 - [ ] Straumen Nett AS - 7080010003720
@@ -292,7 +286,6 @@ Den følgende listen viser status på innsamlede data.
 - [ ] Tinfos AS Nett - 7080003612595
 - [ ] Uvdal Kraftforsyning - 7080005050500
 - [ ] Vang Energiverk AS - 7080010002297
-- [ ] Vest-Telemark Kraftlag AS Nett - 7080005051927
 - [ ] Vestall AS - 7080005051897
 - [ ] Vestmar Nett AS - 7080005054928
 - [x] Vevig AS - 7080003807946 - Sist oppdatert `2024-11-06`

--- a/skript/status.py
+++ b/skript/status.py
@@ -7,6 +7,16 @@ import os
 
 def load_dsos():
 
+    with open('./referanse-data/elhub/grid_owners.json', 'r') as file:
+        gos = json.load(file)
+
+    go_org = {}
+    for go in gos:
+        go_org[go['gln']] = go["organisationNumber"]
+
+    with open('./referanse-data/nve/konsesjonar.json', 'r') as file:
+        konsesjoner = set([k["organisasjonsnr"] for k in json.load(file)])
+
     with open('./referanse-data/esett/metering_grid_areas.json', 'r') as file:
         mgas = json.load(file)
 
@@ -14,6 +24,11 @@ def load_dsos():
 
     for mga in mgas:
         if mga['mgaType'] != 'DISTRIBUTION':
+            continue
+
+        org = go_org[mga['dsoCode']]
+
+        if org not in konsesjoner:
             continue
 
         if mga['dsoName'] in dsos:


### PR DESCRIPTION
Jeg tenkte dette skulle være rett frem, men det virker som det er litt inkonsekvente data mellom NVE og eSett/Elhub.
Parkerer det enn så lenge.