### PR TITLE
Lagt til Arva, Asker og BKK

### DIFF
--- a/tariffer/arva.yml
+++ b/tariffer/arva.yml
@@ -1,0 +1,39 @@
+---
+netteier: 'Arva AS'
+gln: '7080005051859'
+sist_oppdatert: '2024-11-27'
+kilder:
+  - 'https://arva.no/hjem/Priser'
+tariffer:
+  - id: 2024-01-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 1020
+        - terskel: 2
+          pris: 2412
+        - terskel: 5
+          pris: 4776
+        - terskel: 10
+          pris: 7140
+        - terskel: 15
+          pris: 9504
+        - terskel: 20
+          pris: 11868
+        - terskel: 25
+          pris: 23664
+        - terskel: 50
+          pris: 35460
+        - terskel: 75
+          pris: 47256
+        - terskel: 100
+          pris: 71340
+    energiledd:
+      grunnpris: 11.6
+      unntak:
+        - navn: Høylast
+          timer: 6-21
+          pris: 23.1

--- a/tariffer/arva.yml
+++ b/tariffer/arva.yml
@@ -37,3 +37,4 @@ tariffer:
         - navn: Høylast
           timer: 6-21
           pris: 23.1
+    gyldig_fra: '2024-01-01'

--- a/tariffer/asker-nett.yml
+++ b/tariffer/asker-nett.yml
@@ -1,0 +1,44 @@
+---
+netteier: 'Asker Nett'
+gln: '7080003858825'
+sist_oppdatert: '2024-11-27'
+kilder:
+  - 'https://askernett.no/nettleie-og-priser/'
+  - 'https://askernett.no/prisliste-for-privatkunder-i-2024/'
+tariffer:
+  - id: 2024-01-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 1776
+        - terskel: 2
+          pris: 2208
+        - terskel: 5
+          pris: 3264
+        - terskel: 10
+          pris: 6816
+        - terskel: 15
+          pris: 8592
+        - terskel: 20
+          pris: 10848
+        - terskel: 25
+          pris: 15360
+        - terskel: 50
+          pris: 24384
+        - terskel: 75
+          pris: 32448
+        - terskel: 100
+          pris: 51840
+    energiledd:
+      grunnpris: 8.96
+      unntak:
+        - navn: Høylast
+          timer: 6-21
+          pris: 15.888
+        - navn: Vinterlast
+          måneder: [januar, februar, mars]
+          tillegg: 8
+    gyldig_fra: '2024-01-01'

--- a/tariffer/bkk.yml
+++ b/tariffer/bkk.yml
@@ -1,0 +1,48 @@
+---
+netteier: 'BKK AS '
+gln: '7080005051378'
+sist_oppdatert: '2024-11-27'
+kilder:
+  - 'https://www.bkk.no/alt-om-nettleie/nettleiepriser'
+tariffer:
+  - id: 2024-04-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 1536
+        - terskel: 2
+          pris: 2496
+        - terskel: 5
+          pris: 4128
+        - terskel: 10
+          pris: 5952
+        - terskel: 15
+          pris: 7680
+        - terskel: 20
+          pris: 9360
+        - terskel: 25
+          pris: 17952
+        - terskel: 50
+          pris: 26496
+        - terskel: 75
+          pris: 35040
+        - terskel: 100
+          pris: 69120
+    energiledd:
+      grunnpris: 19.776
+      unntak:
+        - navn: 'Høylast sommer'
+          timer: 6-21
+          pris: 29.96
+        - navn: 'Høylast vinter'
+          timer: 6-21
+          måneder: [januar, februar, mars]
+          pris: 22.76
+        - navn: 'Vanlig last vinter'
+          timer: 22-6
+          måneder: [januar, februar, mars]
+          pris: 12.848
+    gyldig_fra: '2024-04-01'


### PR DESCRIPTION
Når man har både dag- og nattpris + sommer- og vinterpris som i BKKs tilfelle synes jeg det blir smått rotete med den unntaksmetodikken. 

Arva har 2 GLN men de har samme nettleie på begge, skal vi kalle dem arva1 og arva2 fx eller skal vi bare fjerne ene fra lista? 
Samme med Glitre