### PR TITLE
Tariffer for Lede

### DIFF
--- a/tariffer/lede.yml
+++ b/tariffer/lede.yml
@@ -1,0 +1,40 @@
+---
+netteier: 'Lede AS'
+gln:
+  - '7080005050975'
+sist_oppdatert: '2024-12-02'
+kilder:
+  - 'https://lede.no/getfile.php/1353399-1720173926/Lede/Filer/Prislister/Priser%20nettleie%2001.08.24.pdf'
+  - 'https://lede.no/priser/nettleie-privatkunder/'
+tariffer:
+  - id: 2024-08-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 2820
+        - terskel: 5
+          pris: 4824
+        - terskel: 10
+          pris: 6792
+        - terskel: 15
+          pris: 8796
+        - terskel: 20
+          pris: 10788
+        - terskel: 25
+          pris: 16764
+        - terskel: 50
+          pris: 26724
+        - terskel: 75
+          pris: 36672
+        - terskel: 100
+          pris: 51612
+        - terskel: 150
+          pris: 71520
+        - terskel: 200
+          pris: 101400
+    energiledd:
+      grunnpris: 24.38
+    gyldig_fra: '2024-08-01'


### PR DESCRIPTION
Ting å merke seg:
- Energileddet til Lede er likt i alle døgnets timer

Ikke støttet (tror heller ikke det er innenfor målet):
- Har ikke lagt til tariffer som er annerledes for kunder med forbruk over 100 000 kWh/år + anlegget har hovedsikringer tørre enn 160 A ved 230 V eller 100 A ved 400 V, såkalt "Nettleie NK1/NK - R - Effekttariff lavspent"

