### PR TITLE
Havnett tariffer

### DIFF
--- a/tariffer/havnett.yml
+++ b/tariffer/havnett.yml
@@ -1,0 +1,27 @@
+---
+netteier: 'Havnett AS'
+gln:
+  - '7080010001832'
+sist_oppdatert: '2024-12-12'
+kilder:
+  - 'https://www.aknett.no/Produkt-og-tenester/Priser/Nettleigetariff'
+tariffer:
+  - id: 2024-08-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 200
+        - terskel: 5
+          pris: 256
+        - terskel: 10
+          pris: 450.4
+        - terskel: 15
+          pris: 630.4
+        - terskel: 20
+          pris: 690.4
+    energiledd:
+      grunnpris: 29.72
+    gyldig_fra: '2024-08-01'


### PR DESCRIPTION
NB: har bare samlet til Trinn 5, og det er med vilje. Fikk bekreftet på mail at dersom en privatperson overstiger 25 kW, så gjelder maks trinn 5 for private

<img width="565" alt="Skjermbilde 2024-12-12 kl  13 39 47" src="https://github.com/user-attachments/assets/80a12782-3fdb-411b-b236-fc7c63ec7132" />
