### PR TITLE
Lagt til manglende trinn for Rakkestad

### DIFF
--- a/tariffer/rakkestadenerginett.yml
+++ b/tariffer/rakkestadenerginett.yml
@@ -23,6 +23,16 @@ tariffer:
           pris: 5760
         - terskel: 15
           pris: 7080
+        - terskel: 20
+          pris: 8640
+        - terskel: 25
+          pris: 15600
+        - terskel: 50
+          pris: 24000
+        - terskel: 75
+          pris: 30000
+        - terskel: 100
+          pris: 60000
     energiledd:
       grunnpris: 21
       unntak:


### PR DESCRIPTION
 trinn 6-10 for Rakkestad for priser fra 2024-07-01 er nå lagt til. 
 Lagt til bilde for kilde
![image001](https://github.com/user-attachments/assets/e813cb57-c2f0-4728-ab26-fd6e20b4d529)
