### PR TITLE
Straumen priser 2025 + 2024 korrigering

### DIFF
--- a/tariffer/straumen-nett.yml
+++ b/tariffer/straumen-nett.yml
@@ -27,7 +27,7 @@ tariffer:
         - terskel: 25
           pris: 11164.8
     energiledd:
-      grunnpris: 17.814
+      grunnpris: 18.304
     gyldig_fra: '2024-10-01'
     gyldig_til: '2025-01-01'
   - id: 2025-01-privat
@@ -49,5 +49,5 @@ tariffer:
         - terskel: 25
           pris: 11164.8
     energiledd:
-      grunnpris: 18.302
+      grunnpris: 18.304
     gyldig_fra: '2025-01-01'

--- a/tariffer/straumen-nett.yml
+++ b/tariffer/straumen-nett.yml
@@ -5,7 +5,8 @@ gln:
 kilder:
   - 'https://www.straumen-nett.no/nettleige/'
   - 'https://www.straumen-nett.no/nettleige/nettleige-private-2024/'
-sist_oppdatert: '2024-12-10'
+  - 'https://www.straumen-nett.no/nettleige/nettleige-private-2025/'
+sist_oppdatert: '2024-12-28'
 tariffer:
   - id: '2024'
     kundegruppe: privat
@@ -26,5 +27,27 @@ tariffer:
         - terskel: 25
           pris: 11164.8
     energiledd:
-      grunnpris: 18.304
+      grunnpris: 17.814
     gyldig_fra: '2024-10-01'
+    gyldig_til: '2025-01-01'
+  - id: 2025-01-privat
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 2784
+        - terskel: 5
+          pris: 3206.4
+        - terskel: 10
+          pris: 4752
+        - terskel: 15
+          pris: 5587.2
+        - terskel: 20
+          pris: 8380.8
+        - terskel: 25
+          pris: 11164.8
+    energiledd:
+      grunnpris: 18.302
+    gyldig_fra: '2025-01-01'


### PR DESCRIPTION

<img width="794" alt="Skjermbilde 2024-12-28 kl  02 36 18" src="https://github.com/user-attachments/assets/be10cc56-52be-4e1b-be6c-c3e8fbe1573c" />
<img width="795" alt="Skjermbilde 2024-12-28 kl  02 36 28" src="https://github.com/user-attachments/assets/db1dac25-a8a6-4763-9d0a-0aa447de8d44" />
Totalprisen vises forskjellig fra 2024 og 2025, men prisen ink mva og enova er like for 2024 og 2025. Har nå brukt totalpris som utgangspunkt. Sender mail for å sjekke dette.