### PR TITLE
samle area nett

### DIFF
--- a/tariffer/areanett.yml
+++ b/tariffer/areanett.yml
@@ -1,0 +1,106 @@
+---
+netteier: 'Area Nett AS'
+gln:
+  - '7080004087071'
+sist_oppdatert: '2025-01-14'
+kilder:
+  - 'https://www.area.no/kunde-og-nettleie/priser-og-nettleie/'
+  - 'https://www.area.no/getfile.php/131319-1734525121/Filer/PRISBLAD%20TARIFFER%202025.pdf'
+tariffer:
+  - id: gamle-nettinord
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 6300
+        - terskel: 2
+          pris: 6615
+        - terskel: 5
+          pris: 7245
+        - terskel: 10
+          pris: 10080
+        - terskel: 15
+          pris: 12140
+        - terskel: 20
+          pris: 14030
+        - terskel: 25
+          pris: 17180
+    energiledd:
+      grunnpris: 26.89
+      unntak:
+        - navn: 'Lavlast sommer'
+          timer: 22-5
+          pris: 24.89
+          måneder: [april, mai, juni, juli, august, september, oktober, november, desember]
+        - navn: 'Høylast vinter'
+          timer: 6-21
+          måneder: [januar, februar, mars]
+          pris: 29.89
+    gyldig_fra: '2025-01-01'
+  - id: gamle-lega
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 3300
+        - terskel: 2
+          pris: 4290
+        - terskel: 5
+          pris: 5280
+        - terskel: 10
+          pris: 8580
+        - terskel: 15
+          pris: 10065
+        - terskel: 20
+          pris: 11880
+        - terskel: 25
+          pris: 13200
+    energiledd:
+      grunnpris: 21.3
+      unntak:
+        - navn: 'Lavlast - sommer'
+          timer: 22-5
+          pris: 19.3
+          måneder: [april, mai, juni, juli, august, september, oktober, november, desember]
+        - navn: 'Høylast - vinter'
+          timer: 6-21
+          måneder: [januar, februar, mars]
+          pris: 24.3
+    gyldig_fra: '2025-01-01'
+  - id: gamle-luostejok
+    kundegruppe: privat
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 3900
+        - terskel: 2
+          pris: 6552
+        - terskel: 5
+          pris: 8580
+        - terskel: 10
+          pris: 10764
+        - terskel: 15
+          pris: 12480
+        - terskel: 20
+          pris: 14508
+        - terskel: 25
+          pris: 24648
+    energiledd:
+      grunnpris: 26.89
+      unntak:
+        - navn: 'Lavlast - sommer'
+          timer: 22-5
+          pris: 23.89
+          måneder: [april, mai, juni, juli, august, september, oktober, november, desember]
+        - navn: 'Høylast - vinter'
+          timer: 6-21
+          måneder: [januar, februar, mars]
+          pris: 29.89
+    gyldig_fra: '2025-01-01'
+    


### PR DESCRIPTION
Denne ble litt snål med flere tariffer på samme GLN. 
Separerte prisene med ID foreløpig, så har vi dem hvertfall - helt til vi skroter ID da.

Den ble snål enda en gang fordi sommer_dag = vinter_natt på alle 3 tariffene. 
Derfor ble dette grunnprisen, også ble det ett unntak for sommer_natt og ett for vinter_dag. 

Må endres igjen sammen med #66 