### PR TITLE
Fix straumnett priser

### DIFF
--- a/tariffer/straumnett.yml
+++ b/tariffer/straumnett.yml
@@ -4,7 +4,7 @@ gln:
   - '7080004053632'
 kilder:
   - 'https://straumnett.no/prisar-for-nettleige'
-sist_oppdatert: '2024-11-25'
+sist_oppdatert: '2025-02-04'
 tariffer:
   - kundegruppe: privat
     gyldig_fra: '2024-01-01'
@@ -33,8 +33,8 @@ tariffer:
         - terskel: 100
           pris: 6088.416
     energiledd:
-      grunnpris: 11.56
+      grunnpris: 11.07
       unntak:
         - navn: Dag
           timer: 6-21
-          pris: 16.56
+          pris: 16.07


### PR DESCRIPTION
Ser ut til at det var en liten feil i energiledd. 

Har sjekket med waybackmachine at prisene er like. 

EDIT: de har bare glemt å oppdatere til ny energiledd med vintersats. De bruker fremdeles forbruksavgiften for 2024 i utregningen i skjermbilde under
![Skjermbilde 2025-02-04 kl  23 51 17](https://github.com/user-attachments/assets/5f785299-9f2b-40cd-b6e8-24eca00c3dbd)
