### PR TITLE
fix incorrect prices linja sør and nord

### DIFF
--- a/tariffer/linja-nord.yml
+++ b/tariffer/linja-nord.yml
@@ -7,14 +7,14 @@ mga:
 kilder:
   - 'https://www.linja.no/nettleige'
 netteier: 'Linja AS - Nord (Mørenett)'
-sist_oppdatert: '2024-12-27'
+sist_oppdatert: '2025-06-23'
 tariffer:
   - energiledd:
-      grunnpris: 20.424
+      grunnpris: 15.384
       unntak:
         - navn: Høylast
-          pris: 27.232
-          timer: 6-21
+          pris: 22.384
+          timer: 6-22
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true

--- a/tariffer/linja-nord.yml
+++ b/tariffer/linja-nord.yml
@@ -14,7 +14,7 @@ tariffer:
       unntak:
         - navn: Høylast
           pris: 22.384
-          timer: 6-22
+          timer: 6-21
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true

--- a/tariffer/linja-sor.yml
+++ b/tariffer/linja-sor.yml
@@ -9,14 +9,14 @@ mga:
 kilder:
   - 'https://www.linja.no/nettleige'
 netteier: 'Linja AS - Sør'
-sist_oppdatert: '2024-12-27'
+sist_oppdatert: '2025-06-23'
 tariffer:
   - energiledd:
-      grunnpris: 15.384
+      grunnpris: 20.424
       unntak:
         - navn: Høylast
-          pris: 22.384
-          timer: 6-21
+          pris: 27.232
+          timer: 6-22
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true

--- a/tariffer/linja-sor.yml
+++ b/tariffer/linja-sor.yml
@@ -16,7 +16,7 @@ tariffer:
       unntak:
         - navn: Høylast
           pris: 27.232
-          timer: 6-22
+          timer: 6-21
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
Oppdaga feil energiledd-pris for Linja sør og såg at det var fordi grunnpris energiledd var bytta om for Linja sør og Linja nord. 

Bytter om dette og justerer så perioden for høglast prising blir korrekt. 

Fastledd / terskelpriser ser ut til å vere riktig. 