### PR TITLE
samle: elvia har lik pris på næring

### DIFF
--- a/tariffer/elvia.yml
+++ b/tariffer/elvia.yml
@@ -2,11 +2,11 @@
 netteier: 'Elvia AS'
 gln:
   - '7080005046220'
-sist_oppdatert: '2025-03-29'
+sist_oppdatert: '2025-10-22'
 kilder:
-  - 'https://www.elvia.no/nettleie/alt-om-nettleiepriser/nettleiepriser-for-privatkunder/'
   - 'https://www.elvia.no/nettleie/alt-om-nettleiepriser/'
   - 'https://www.elvia.no/nettleie/alt-om-nettleiepriser/nettleie-pris/'
+  - 'https://www.elvia.no/nettleie/alt-om-nettleiepriser/nettleiepriser-for-bedrifter-og-naring/'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -83,6 +83,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.elvia.no/nettleie/alt-om-nettleiepriser/nettleiepriser-for-bedrifter-og-naring/

> Bedrifter og næringskunder med et årsforbruk under 100.000 kWh går inn i samme type modell som privatkunder.