### PR TITLE
samle: area har lik pris på næring

### DIFF
--- a/tariffer/area-lega.yml
+++ b/tariffer/area-lega.yml
@@ -2,7 +2,7 @@
 netteier: 'Area Nett AS - Lega'
 gln:
   - '7080004087071'
-sist_oppdatert: '2025-01-14'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://www.area.no/kunde-og-nettleie/priser-og-nettleie/'
   - 'https://www.area.no/getfile.php/131319-1734525121/Filer/PRISBLAD%20TARIFFER%202025.pdf'
@@ -10,6 +10,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true

--- a/tariffer/area-luostejok.yml
+++ b/tariffer/area-luostejok.yml
@@ -2,7 +2,7 @@
 netteier: 'Area Nett AS - Luostejok'
 gln:
   - '7080004087071'
-sist_oppdatert: '2025-01-14'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://www.area.no/kunde-og-nettleie/priser-og-nettleie/'
   - 'https://www.area.no/getfile.php/131319-1734525121/Filer/PRISBLAD%20TARIFFER%202025.pdf'
@@ -10,6 +10,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true

--- a/tariffer/area-nettinord.yml
+++ b/tariffer/area-nettinord.yml
@@ -2,7 +2,7 @@
 netteier: 'Area Nett AS - NettiNord'
 gln:
   - '7080004087071'
-sist_oppdatert: '2025-01-14'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://www.area.no/kunde-og-nettleie/priser-og-nettleie/'
   - 'https://www.area.no/getfile.php/131319-1734525121/Filer/PRISBLAD%20TARIFFER%202025.pdf'
@@ -10,6 +10,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.area.no/getfile.php/131429-1737538132/Filer/Tariffer%202025.pdf De oppgitte prisene er med enova-avgift, men hvis man ser bort fra det er prisene like.

https://www.area.no/kunde-og-nettleie/priser-og-nettleie/

Omtalt som en kategori

> Husholdning, hytter, gatelys og næring under 100 000 kWh