### PR TITLE
samle: barents har lik pris for næring

### DIFF
--- a/tariffer/barentsnett.yml
+++ b/tariffer/barentsnett.yml
@@ -5,7 +5,7 @@ gln:
 kilder:
   - 'https://www.barents-nett.no/kundeservice/nett-og-nettleie/'
   - 'https://www.barents-nett.no/getfile.php/1314116-1751007532/Dokumenter/Nett/Nettleie/Nettleiebrosjyre%2001.07.2025.pdf'
-sist_oppdatert: '2025-07-02'
+sist_oppdatert: '2025-10-22'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -33,6 +33,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.barents-nett.no/getfile.php/1314116-1751007532/Dokumenter/Nett/Nettleie/Nettleiebrosjyre%2001.07.2025.pdf

> Nettleie – Nærings- og husholdningsanlegg med årsforbruk under 100 000 kW