### PR TITLE
samle: bkk har lik pris for næring

### DIFF
--- a/tariffer/bkk.yml
+++ b/tariffer/bkk.yml
@@ -79,4 +79,4 @@ tariffer:
           timer: 6-21
           dager: [virkedag]
           pris: 28.77
-    gyldig_fra: '2025-09-01'
+    gyldig_fra: '2025-10-01'


### PR DESCRIPTION
https://www.bkk.no/alt-om-nettleie/nettleie-for-bedriftskunder

Prisene stemmer helt med våre data