### PR TITLE
samle: de nett har lik pris for næring

### DIFF
--- a/tariffer/denett.yml
+++ b/tariffer/denett.yml
@@ -2,7 +2,7 @@
 netteier: 'DE Nett AS'
 gln:
   - '7080010003614'
-sist_oppdatert: '2025-01-15'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://denett.no/priser-tariffer'
   - 'https://denett.no/uploads/Nettleietariffer-fra-01.01.2025.pdf'
@@ -10,6 +10,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://denett.no/uploads/Nettleietariffer-fra-01.01.2025.pdf

> Privat og næring under 100 000 kWh årlig inkl. byggekasser