### PR TITLE
samle: elmea har lik pris for næring

### DIFF
--- a/tariffer/elmea.yml
+++ b/tariffer/elmea.yml
@@ -2,13 +2,14 @@
 netteier: 'Elmea AS Nett'
 gln:
   - '7080005046442'
-sist_oppdatert: '2025-01-09'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://www.elmea.no/nettleiepriser/'
 tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.elmea.no/nettleiepriser/

> Priser som gjelder fra 1.1.2025 for husholdning, hytte/fritid, liten næring og målt gatelys