### PR TITLE
samle: elvenett har lik pris for næring

### DIFF
--- a/tariffer/elvenett.yml
+++ b/tariffer/elvenett.yml
@@ -2,7 +2,7 @@
 netteier: 'Elvenett AS'
 gln:
   - '7080005052917'
-sist_oppdatert: '2025-05-03'
+sist_oppdatert: '2025-10-22'
 kilder:
   - 'https://www.elvenett.no/priser-og-avtaler/'
   - 'https://www.elvenett.no/media/guapqy0g/nye-priser-privat-01042025_nye-trinn.pdf'
@@ -39,6 +39,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.elvenett.no/media/ypnh0sf1/nye-priser-privat-01042025_nye-trinn.pdf

> Nettleiepriser for privatkunder og mindre næring pr 01.04.2025