### PR TITLE
samle: føie har lik pris for næring

### DIFF
--- a/tariffer/foie.yml
+++ b/tariffer/foie.yml
@@ -11,7 +11,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
-      - liten_husholdning
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.foie.no/nettleie/priser

> Husholdning, fritidsbolig og næringskunder under 100 000 kWt/år