### PR TITLE
samle: griug har lik pris på næring

### DIFF
--- a/tariffer/griug.yml
+++ b/tariffer/griug.yml
@@ -2,10 +2,9 @@
 gln:
   - '7080005052900'
 kilder:
-  - 'https://www.griug.no/om-nettleie-og-priser/priser/'
   - 'https://www.griug.no/om-nettleie-og-priser/priser/nettleiepriser-2025/'
 netteier: 'Griug AS'
-sist_oppdatert: '2025-03-30'
+sist_oppdatert: '2025-10-22'
 tariffer:
   - energiledd:
       grunnpris: 9.8
@@ -47,6 +46,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
https://www.griug.no/om-nettleie-og-priser/priser/nettleiepriser-2024/

skiller kun på 100k, ikke privat/næring