### PR TITLE
samle: bomlø har samme pris for næring

### DIFF
--- a/tariffer/bomlokraftnett.yml
+++ b/tariffer/bomlokraftnett.yml
@@ -4,12 +4,13 @@ gln:
   - '7080010002327'
 kilder:
   - 'https://nett.finnas-kraftlag.no/nettleige-og-vilkar/category1618.html'
-  - 'https://nett.finnas-kraftlag.no/getfile.php/139292-1734615691/Filer/NETT/Tariffar/Tariffar%20B%C3%B8mlo%20Kraftnett%20AS%20gjeldande%20fr%C3%A5%2001.01.25%20Etter%20RME%20endring%281%29.pdf'
-sist_oppdatert: '2025-01-15'
+  - 'https://nett.finnas-kraftlag.no/getfile.php/139943-1759240439/Bilder/NETT/Kundeservice/Tariffar/Tariffar%20B%C3%B8mlo%20Kraftnett%20AS%20gjeldande%20fr%C3%A5%2001.10.25%20endra%20elavgift.pdf'
+sist_oppdatert: '2025-10-23'
 tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true
@@ -35,9 +36,9 @@ tariffer:
         - terskel: 100
           pris: 48000
     energiledd:
-      grunnpris: 26.064
+      grunnpris: 26.06
       unntak:
         - navn: Høylast
           timer: 6-21
-          pris: 31.064
+          pris: 31.06
     gyldig_fra: '2025-01-01'


### PR DESCRIPTION
https://nett.finnas-kraftlag.no/getfile.php/139943-1759240439/Bilder/NETT/Kundeservice/Tariffar/Tariffar%20B%C3%B8mlo%20Kraftnett%20AS%20gjeldande%20fr%C3%A5%2001.10.25%20endra%20elavgift.pdf

Lik våre priser. Fiksa en avrundingsfeil i samme slengen.