### PR TITLE
Bugfix elinett

### DIFF
--- a/tariffer/elinett.yml
+++ b/tariffer/elinett.yml
@@ -15,25 +15,25 @@ tariffer:
       terskel_inkludert: true
       terskler:
         - terskel: 0
-          pris: 2409.6
+          pris: 2412
         - terskel: 2
-          pris: 3014.4
+          pris: 3012
         - terskel: 5
-          pris: 3609.6
+          pris: 3612
         - terskel: 10
-          pris: 6019.2
+          pris: 6024
         - terskel: 15
-          pris: 7228.8
+          pris: 7224
         - terskel: 20
-          pris: 8428.8
+          pris: 8424
         - terskel: 25
-          pris: 12038.4
+          pris: 12036
         - terskel: 50
-          pris: 13238.4
+          pris: 13248
         - terskel: 75
           pris: 14448
         - terskel: 100
-          pris: 18057.6
+          pris: 18060
     energiledd:
       grunnpris: 17.84
       unntak:
@@ -52,25 +52,25 @@ tariffer:
       terskel_inkludert: true
       terskler:
         - terskel: 0
-          pris: 2409.6
+          pris: 2412
         - terskel: 2
-          pris: 3014.4
+          pris: 3012
         - terskel: 5
-          pris: 3609.6
+          pris: 3612
         - terskel: 10
-          pris: 6019.2
+          pris: 6024
         - terskel: 15
-          pris: 7228.8
+          pris: 7224
         - terskel: 20
-          pris: 8428.8
+          pris: 8424
         - terskel: 25
-          pris: 12038.4
+          pris: 12036
         - terskel: 50
-          pris: 13238.4
+          pris: 13248
         - terskel: 75
           pris: 14448
         - terskel: 100
-          pris: 18057.6
+          pris: 18060
     energiledd:
       grunnpris: 14.64
       unntak:


### PR DESCRIPTION
Elinett har helt like fastledd for 1 april -> 1 august og den neste perioden.

Rart nok klarer jeg bare å finne priser for 1 April -> 1 August og 1 Oktober og utover.
Mangler altså september på nettsiden, men antar det bare er en feil i visningen.

<img width="599" height="495" alt="image" src="https://github.com/user-attachments/assets/213b6e2e-fc6f-4f8f-bc00-02378ca4fd49" />
<img width="599" height="495" alt="image" src="https://github.com/user-attachments/assets/3da71167-714d-4e6f-95e5-3c434ac89fcc" />