### PR TITLE
samle: norgesnett har lik pris for liten næring

### DIFF
--- a/tariffer/norgesnett.yml
+++ b/tariffer/norgesnett.yml
@@ -4,7 +4,8 @@ gln:
   - '7080005052702'
 kilder:
   - 'https://norgesnett.no/kunde/nettleie-privat/'
-sist_oppdatert: '2024-11-01'
+  - 'https://norgesnett.no/kunde/nettleie-naering/'
+sist_oppdatert: '2025-11-09'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -44,6 +45,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: TRE_DØGNMAX_MND
       terskel_inkludert: true


### PR DESCRIPTION
Lik pris:

* https://norgesnett.no/kunde/nettleie-naering/
* https://norgesnett.no/kunde/nettleie-privat/

MERK at prisene ikke ser like ut, men for næring så:

> Prisene er inkl. ENOVA avgift i kapasitetsleddet. ENOVA avgift er kr. 800 pr.år (kr. 66,67 pr. mnd).