### PR TITLE
samle: noranett har lik pris for liten næring

### DIFF
--- a/tariffer/noranett-andoy.yml
+++ b/tariffer/noranett-andoy.yml
@@ -6,7 +6,7 @@ kilder:
   - 'https://www.noranett.no/nettleiepriser/category2415.html'
   - 'https://www.noranett.no/nettleiepriser/nettleiepriser-andoy-fra-1-1-2024-article3871-2415.html'
   - 'https://www.noranett.no/getfile.php/1326762-1736159187/Noranett/Filer/Kopi%20av%20Nettleie%202025%20-%20And%C3%B8y%20pdf.pdf'
-sist_oppdatert: '2024-11-29'
+sist_oppdatert: '2025-11-22'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -60,6 +60,7 @@ tariffer:
     gyldig_fra: '2024-01-01'
     gyldig_til: '2025-01-01'
   - kundegrupper:
+      - liten_næring
       - husholdning
       - fritid
     fastledd:

--- a/tariffer/noranett-hadsel.yml
+++ b/tariffer/noranett-hadsel.yml
@@ -2,7 +2,7 @@
 netteier: 'Noranett Hadsel AS'
 gln:
   - '7080003857989'
-sist_oppdatert: '2024-11-29'
+sist_oppdatert: '2025-11-22'
 kilder:
   - 'https://www.noranett.no/nettleiepriser/category2415.html'
   - 'https://www.noranett.no/nettleiepriser/nettleiepriser-hadsel-fra-1-10-2024-article3982-2415.html'
@@ -64,6 +64,7 @@ tariffer:
     gyldig_fra: '2024-01-01'
     gyldig_til: '2025-01-01'
   - kundegrupper:
+      - liten_næring
       - husholdning
       - fritid
     fastledd:

--- a/tariffer/noranett.yml
+++ b/tariffer/noranett.yml
@@ -7,7 +7,7 @@ kilder:
   - 'https://www.noranett.no/getfile.php/1323306-1704953748/Noranett/Filer/Nettleie%202024%20-%20H%C3%A5logaland%20pdf.pdf'
   - 'https://www.noranett.no/nettleiepriser/nettleiepriser-halogaland-fra-1-1-2024-article3870-2415.html'
   - 'https://www.noranett.no/getfile.php/1326768-1736159212/Noranett/Filer/Kopi%20av%20Nettleie%202025%20-%20H%C3%A5logaland%20pdf.pdf'
-sist_oppdatert: '2025-01-09'
+sist_oppdatert: '2025-11-22'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -61,6 +61,7 @@ tariffer:
     gyldig_fra: '2024-01-01'
     gyldig_til: '2025-01-01'
   - kundegrupper:
+      - liten_næring
       - husholdning
       - fritid
     fastledd:


### PR DESCRIPTION
feks https://www.noranett.no/nettleiepriser/nettleiepriser-andoy-fra-1-1-2025-article4004-2415.html

> gjelder for kunder med årsforbruk mindre enn 100.000 kWh (husholdning, hytte/fritid, liten næring og gatelys).

