### PR TITLE
fiks: griug avvikler brukstidstillegg fra 2025-04-01

### DIFF
--- a/tariffer/griug.yml
+++ b/tariffer/griug.yml
@@ -73,5 +73,4 @@ tariffer:
           pris: 78240
     energiledd:
       grunnpris: 12.32
-      unntak:
     gyldig_fra: '2025-01-01'


### PR DESCRIPTION
Brukstidstillegget avvikles med virkning fra 1. april 2025
Kilde: https://www.griug.no/om-nettleie-og-priser/priser/nettleiepriser-2025/