### PR TITLE
Oppdatere forbruksavgift for 2026

### DIFF
--- a/docs/innsamler/index.html
+++ b/docs/innsamler/index.html
@@ -73,7 +73,7 @@
                 <li><b>2025-01</b>: 9.79</li>
                 <li><b>2025-04</b>: 16.93</li>
                 <li><b>2025-10</b>: 12.53</li>
-                <li><b>2026-01</b>: TBD</li>
+                <li><b>2026-01</b>: 7.13</li>
             </ul>
         </p>
     </div>
@@ -419,7 +419,7 @@
                     tariffer: [structuredClone(newTariff)]
                 },
                 meta: {
-                    forbruksavgift: 12.53
+                    forbruksavgift: 7.13
                 },
                 init() {
                     this.getDataFromUrl();


### PR DESCRIPTION
Usikker om jeg oppdaterte alle de rette stedene 🤔 Fulgte [PR-#190](https://github.com/kraftsystemet/fri-nettleie/pull/190/files)

Skatteetaten har ikke lagt ut noen oppdatering på prisen enda, men individuelle netteiere har begynt å ta 7.13 i bruk.

<img width="613" height="107" alt="image" src="https://github.com/user-attachments/assets/499fa5e6-6691-441d-9890-7ea2791bc779" />

_(BKK)_
