### PR TITLE
feat: bruk postnummer netteiere som har flere tariffer per mga

### DIFF
--- a/tariff-eksempel.yml
+++ b/tariff-eksempel.yml
@@ -36,6 +36,11 @@ gln:
 mga:
   - 50Y12315125158JK
   - 50Y12315125158JS
+# Postnummer kan brukes dersom en netteier har flere tariffer i sine MGA.
+# Skal være en liste. Dersom postnummer er utelatt vil alle postnummer være aktuelle.
+postnummer:
+  - "1234"
+  - "2312"
 # Når det sist ble samlet inn/sjekket at tariffene er riktige
 sist_oppdatert: 2024-11-03
 # Kilder er lenker/urler hvor tariffene finnes.

--- a/tariff.cue
+++ b/tariff.cue
@@ -8,13 +8,15 @@ import (
 // https://cuelang.org/docs/concept/how-cue-enables-data-validation/
 // https://cuelang.org/docs/concept/how-cue-works-with-yaml/
 
-#MGA: =~"^50Y[A-Z0-9-]{10}"
+#MGA: =~"^50Y[A-Z0-9-]{13}$"
 #GLN: =~"^7080[0-9]{9}$"
+#Postnummer: =~"^[0-9]{4}$"
 
 #Selskap: {
     netteier!: string
     gln!: [...#GLN]
     mga?: [...#MGA]
+    postnummer?: [...#Postnummer]
     sist_oppdatert!: time.Format(time.RFC3339Date)
     kilder!: list.MinItems(1)
     tariffer!: [...#Tariff]

--- a/tariffer/area-lega.yml
+++ b/tariffer/area-lega.yml
@@ -2,6 +2,18 @@
 netteier: 'Area Nett AS - Område 3 - Lega'
 gln:
   - '7080004087071'
+mga:
+  - '50YBD6LZSE57I49Q'
+postnummer:
+ - '9740' # LEBESBY
+ - '9742' # KUNES
+ - '9770' # MEHAMN
+ - '9771' # SKJÅNES
+ - '9772' # LANGFJORDNES
+ - '9773' # NERVEI
+ - '9775' # GAMVIK
+ - '9782' # DYFJORD
+ - '9790' # KJØLLEFJORD
 sist_oppdatert: '2025-12-20'
 kilder:
   - 'https://www.area.no/kunde-og-nettleie/priser-og-nettleie/'


### PR DESCRIPTION
Ref #86 

Dette viser et eksempel på hvordan vi kan bruke postnummer for å fange opp det at area har flere tariffer på et mga.

Draft fordi det mangler endringer i:

* innsamler
* tariff-beskrivelser
