### PR TITLE
Mellom, Romsdalsnett, S-Nett, Straumnett: trekk forbruksavgift+Enova fra energiledd

### DIFF
--- a/tariffer/mellom.yml
+++ b/tariffer/mellom.yml
@@ -4,7 +4,7 @@ gln:
   - '7080010004369'
 kilder:
   - 'https://mellom.no/nettleie/nettleiepriser/'
-sist_oppdatert: '2025-11-12'
+sist_oppdatert: '2026-05-25'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -31,9 +31,9 @@ tariffer:
         - terskel: 50
           pris: 21369.6
     energiledd:
-      grunnpris: 23.47
+      grunnpris: 15.34
       unntak:
         - navn: Høylast
           timer: 6-21
-          pris: 29.77
+          pris: 21.64
     gyldig_fra: '2024-08-01'

--- a/tariffer/romsdalsnett.yml
+++ b/tariffer/romsdalsnett.yml
@@ -5,7 +5,7 @@ gln:
 kilder:
   - 'https://www.romsdalsnettas.no/nettleie#block-65b22d41f1b4d4addd134ddf'
   - 'https://www.romsdalsnettas.no/s/Tariff-01012026-eelt.pdf'
-sist_oppdatert: '2025-01-25'
+sist_oppdatert: '2026-05-25'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -73,10 +73,10 @@ tariffer:
         - terskel: 100
           pris: 27828
     energiledd:
-      grunnpris: 20.72
+      grunnpris: 12.59
       unntak:
         - navn: Ukedager
           timer: 6-21
-          pris: 30.72
+          pris: 22.59
           dager: [ukedag]
     gyldig_fra: '2026-01-01'

--- a/tariffer/snett.yml
+++ b/tariffer/snett.yml
@@ -4,7 +4,7 @@ gln:
   - '7080010002464'
 kilder:
   - 'https://snett.no/nettleie-forbruk-under-100-000-kwh'
-sist_oppdatert: '2025-09-19'
+sist_oppdatert: '2026-05-25'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -77,10 +77,10 @@ tariffer:
         - terskel: 200
           pris: 99264
     energiledd:
-      grunnpris: 21.41
+      grunnpris: 13.28
       unntak:
         - navn: Dag
           timer: 6-21
-          pris: 26.4
+          pris: 18.27
           dager: [alle]
     gyldig_fra: '2025-01-01'

--- a/tariffer/straumnett.yml
+++ b/tariffer/straumnett.yml
@@ -4,7 +4,7 @@ gln:
   - '7080004053632'
 kilder:
   - 'https://straumnett.no/prisar-for-nettleige'
-sist_oppdatert: '2026-04-15'
+sist_oppdatert: '2026-05-25'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -105,10 +105,10 @@ tariffer:
         - terskel: 100
           pris: 10512
     energiledd:
-      grunnpris: 15.96
+      grunnpris: 7.83
       unntak:
         - navn: Høylast
           timer: 6-21
-          pris: 20.96
+          pris: 12.83
           dager: [alle]
     gyldig_fra: '2026-01-01'


### PR DESCRIPTION
Ref #359

Innsamlings-prompten sier "Alle priser skal være UTEN mva og UTEN avgifter". Disse fire har hatt forbruksavgift (7,13) og Enova (1,00) inkludert i energileddet. 8,13 øre/kWh for høyt.

Verifisert mot nettselskapene sine egne sider.

| Nettselskap | Før (grunn / unntak) | Etter | Kilde |
|---|---|---|---|
| Mellom | 23,47 / 29,77 | 15,34 / 21,64 | https://mellom.no/nettleie/nettleiepriser/ |
| Romsdalsnett | 20,72 / 30,72 | 12,59 / 22,59 | https://www.romsdalsnettas.no/s/Tariff-01012026-eelt.pdf |
| S-Nett | 21,41 / 26,40 | 13,28 / 18,27 | https://snett.no/nettleie-forbruk-under-100-000-kwh |
| Straumnett | 15,96 / 20,96 | 7,83 / 12,83 | https://straumnett.no/prisar-for-nettleige |

Utregning Mellom: publisert 37,21/29,34 inkl. mva. ÷1,25 = 29,77/23,47. Trekk 8,13 (forbruksavgift + Enova) = 21,64/15,34.

NB: Eldre tariffer (pre-2026) i samme filer kan ha samme problem, men er ikke verifisert her. Avgift-satsen var ulik i 2024/2025.