### PR TITLE
fix: llms.txt only shows tariffs active on rundate.

### DIFF
--- a/.github/workflows/generate-llms.yml
+++ b/.github/workflows/generate-llms.yml
@@ -1,3 +1,7 @@
+# Generate docs/llm/llms.txt when tariff data changes, when the generator script changes,
+# or on the first day of each month as a safeguard for future-dated tariffs.
+# The monthly schedule is a quick workaround so future tariff periods become active
+# in the generated snapshot even if no new push happens on that day.
 name: Generate llms.txt
 
 on:
@@ -6,7 +10,9 @@ on:
     paths:
       - "tariffer/**"
       - "scripts/generate_llms_txt.py"
-  workflow_dispatch:  # allow manual trigger
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   generate:


### PR DESCRIPTION
That means that if we have tariffs to be updated in the future they wouldnt show unless theres a new PR. Solved by including a small cron on the 1. of each month since that is when the tariffs usually is activated. 