### PR TITLE
fix: gaps from claude

### DIFF
--- a/tariffer/indrehordalandkraftnett.yml
+++ b/tariffer/indrehordalandkraftnett.yml
@@ -32,7 +32,7 @@ tariffer:
     energiledd:
       grunnpris: 28.56
     gyldig_fra: '2024-10-01'
-    gyldig_til: '2025-04-30'
+    gyldig_til: '2025-05-01'
   - kundegrupper:
       - husholdning
       - fritid
@@ -64,7 +64,7 @@ tariffer:
     energiledd:
       grunnpris: 28.55
     gyldig_fra: '2025-05-01'
-    gyldig_til: '2026-05-31'
+    gyldig_til: '2026-06-01'
   - kundegrupper:
       - husholdning
       - fritid

--- a/tariffer/rnett.yml
+++ b/tariffer/rnett.yml
@@ -144,7 +144,7 @@ tariffer:
           pris: 25.67
           dager: [alle]
     gyldig_fra: '2026-01-01'
-    gyldig_til: '2026-05-31'
+    gyldig_til: '2026-06-01'
   - kundegrupper:
       - husholdning
       - fritid


### PR DESCRIPTION
Found with

```
❯ ./scripts/check_overlap_and_gap.py
Gap between 2026-05-31 00:00:00 and 2026-06-01 00:00:00 in rnett.yml for household
Gap between 2026-05-31 00:00:00 and 2026-06-01 00:00:00 in rnett.yml for cabins
Gap between 2025-04-30 00:00:00 and 2025-05-01 00:00:00 in indrehordalandkraftnett.yml for household
Gap between 2026-05-31 00:00:00 and 2026-06-01 00:00:00 in indrehordalandkraftnett.yml for household
Gap between 2025-04-30 00:00:00 and 2025-05-01 00:00:00 in indrehordalandkraftnett.yml for cabins
Gap between 2026-05-31 00:00:00 and 2026-06-01 00:00:00 in indrehordalandkraftnett.yml for cabins
Gap between 2026-05-31 00:00:00 and 2026-06-01 00:00:00 in indrehordalandkraftnett.yml for business
```