### PR TITLE
Elvia: dag-energiledd 28,99 → 29,15 øre (elvia.no oppgir 46,60 inkl.)

### DIFF
--- a/tariffer/elvia.yml
+++ b/tariffer/elvia.yml
@@ -151,5 +151,5 @@ tariffer:
         - navn: Virkedag
           timer: 6-21
           dager: [virkedag]
-          pris: 28.99
+          pris: 29.15
     gyldig_fra: '2026-07-01'


### PR DESCRIPTION
Elvias egen prisside oppgir **46,60 øre/kWh inkl. alle avgifter** for dag (virkedag 6-21) per 01.07.2026: https://www.elvia.no/nettleie/alt-om-nettleiepriser/nettleie-pris/

Med forbruksavgift (7,13) + Enova (1,0) + 25 % mva blir det **29,15 øre eks. avgifter**, ikke 28,99. Natt (grunnpris 16,99 → 31,40 øre inkl.) stemmer allerede eksakt.

Diskusjon i #384 