### PR TITLE
Update norefjell.yml with new prices from 2026-08-01

### DIFF
--- a/tariffer/norefjell.yml
+++ b/tariffer/norefjell.yml
@@ -2,12 +2,13 @@
 netteier: 'Norefjell Nett AS'
 gln:
   - '7080010003911'
-sist_oppdatert: '2025-12-12'
+sist_oppdatert: '2026-08-18'
 kilder:
   - 'https://norefjell-nett.no/strompris'
   - 'https://norefjell-nett.no/uploads/Dok/Nettleiepriser/Nettleiepriser-01.01.2024.pdf'
   - 'https://norefjell-nett.no/uploads/Dok/Nettleiepriser/Nettleiepriser-fra-01.01.2025.pdf'
   - 'https://norefjell-nett.no/uploads/Nettleiepriser-01.01.2026_2025-12-12-102717_wqzu.pdf'
+  - 'https://norefjell-nett.no/uploads/Nettleiepriser-01.08.2026.pdf'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -116,3 +117,40 @@ tariffer:
           pris: 22.53
           dager: [alle]
     gyldig_fra: '2026-01-01'
+    gyldig_til: '2026-08-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 2556
+        - terskel: 2
+          pris: 3324
+        - terskel: 5
+          pris: 4596
+        - terskel: 10
+          pris: 6900
+        - terskel: 15
+          pris: 8940
+        - terskel: 20
+          pris: 10980
+        - terskel: 25
+          pris: 17880
+        - terskel: 50
+          pris: 26820
+        - terskel: 75
+          pris: 35760
+        - terskel: 100
+          pris: 51084
+    energiledd:
+      grunnpris: 18.58
+      unntak:
+        - navn: Dag
+          timer: 6-22
+          pris: 23.53
+          dager: [alle]
+    gyldig_fra: '2026-08-01'


### PR DESCRIPTION
## Summary
- Adds Norefjell Nett AS's new tariff period effective 2026-08-01, closing out the previous 2026-01-01 period.
- Source: [Nettleiepriser-01.08.2026.pdf](https://norefjell-nett.no/uploads/Nettleiepriser-01.08.2026.pdf), linked from https://norefjell-nett.no/strompris

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/norefjell.yml` passes
- [x] `scripts/prissignal.py` picks up the new period correctly for dates after 2026-08-01

closes #388 