### PR TITLE
Update lysna.yml with new prices from 2026-08-01

### DIFF
--- a/tariffer/lysna.yml
+++ b/tariffer/lysna.yml
@@ -2,7 +2,7 @@
 netteier: 'Lysna AS'
 gln:
   - '7080010013088'
-sist_oppdatert: '2025-10-23'
+sist_oppdatert: '2026-08-18'
 kilder:
   - 'https://lysna.no/prisar-for-private-kundar-2024'
   - 'https://lysna.no/prisar-for-mindre-naeringslivskundar-2024-forbruk-under-100-000-kwh-2'
@@ -34,6 +34,35 @@ tariffer:
           timer: 6-21
           pris: 32
     gyldig_fra: '2024-02-01'
+    gyldig_til: '2026-08-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 3600
+        - terskel: 2
+          pris: 4377.6
+        - terskel: 5
+          pris: 5280
+        - terskel: 10
+          pris: 6960
+        - terskel: 15
+          pris: 9060
+        - terskel: 20
+          pris: 11760
+        - terskel: 25
+          pris: 18000
+    energiledd:
+      grunnpris: 26.03
+      unntak:
+        - navn: Dag
+          timer: 6-22
+          pris: 32.03
+    gyldig_fra: '2026-08-01'
   - kundegrupper:
       - liten_næring
     fastledd:
@@ -67,3 +96,37 @@ tariffer:
           timer: 6-21
           pris: 30
     gyldig_fra: '2024-02-01'
+    gyldig_til: '2026-08-01'
+  - kundegrupper:
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 5760
+        - terskel: 2
+          pris: 6480
+        - terskel: 5
+          pris: 7200
+        - terskel: 10
+          pris: 8040
+        - terskel: 15
+          pris: 9240
+        - terskel: 20
+          pris: 10560
+        - terskel: 25
+          pris: 12600
+        - terskel: 50
+          pris: 16080
+        - terskel: 75
+          pris: 19560
+        - terskel: 100
+          pris: 24000
+    energiledd:
+      grunnpris: 25
+      unntak:
+        - navn: Dag
+          timer: 6-22
+          pris: 33
+    gyldig_fra: '2026-08-01'

--- a/tariffer/lysna.yml
+++ b/tariffer/lysna.yml
@@ -4,9 +4,8 @@ gln:
   - '7080010013088'
 sist_oppdatert: '2026-08-18'
 kilder:
-  - 'https://lysna.no/prisar-for-private-kundar-2024'
+  - 'https://lysna.no/prisar-for-private-kundar'
   - 'https://lysna.no/prisar-for-mindre-naeringslivskundar-2024-forbruk-under-100-000-kwh-2'
-  - 'https://lysna.no/prisar-2'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -57,11 +56,11 @@ tariffer:
         - terskel: 25
           pris: 18000
     energiledd:
-      grunnpris: 26.03
+      grunnpris: 26
       unntak:
         - navn: Dag
           timer: 6-22
-          pris: 32.03
+          pris: 32
     gyldig_fra: '2026-08-01'
   - kundegrupper:
       - liten_næring


### PR DESCRIPTION
## Summary
- Adds Lysna AS's new tariff period effective 2026-08-01 for both husholdning/fritid and liten_næring, closing out the previous 2024-02-01 periods.
- Sources:
  - https://lysna.no/prisar-for-private-kundar-2024 (household/cabin)
  - https://lysna.no/prisar-for-mindre-naeringslivskundar-2024-forbruk-under-100-000-kwh-2 (liten_næring)

Closes #389

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/lysna.yml` passes
- [x] `scripts/prissignal.py` picks up the new tariffer for dates after 2026-08-01