### PR TITLE
Update holandogsetskogelverk.yml with new prices from 2026-08-01

### DIFF
--- a/tariffer/holandogsetskogelverk.yml
+++ b/tariffer/holandogsetskogelverk.yml
@@ -2,10 +2,11 @@
 netteier: 'Høland og Setskog Elverk AS'
 gln:
   - '7080004320253'
-sist_oppdatert: '2025-07-11'
+sist_oppdatert: '2026-08-18'
 kilder:
   - 'https://hsev.no/nettleie'
   - 'https://hsev.no/uploads/HSEV-nettleie-privatkunder-1.-juli-2025.pdf'
+  - 'https://hsev.no/uploads/2026-07-06-HSEV-nettleie-privatkunder-2026-08-01-1.pdf'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -114,3 +115,39 @@ tariffer:
           pris: 22.5
           dager: [virkedag]
     gyldig_fra: '2025-07-01'
+    gyldig_til: '2026-08-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 2544
+        - terskel: 2
+          pris: 2880
+        - terskel: 5
+          pris: 4512
+        - terskel: 10
+          pris: 5664
+        - terskel: 15
+          pris: 7296
+        - terskel: 20
+          pris: 8880
+        - terskel: 25
+          pris: 17280
+        - terskel: 50
+          pris: 25920
+        - terskel: 75
+          pris: 33600
+        - terskel: 100
+          pris: 67200
+    energiledd:
+      grunnpris: 23.5
+      unntak:
+        - navn: Virkedag
+          timer: 6-21
+          pris: 27.5
+          dager: [virkedag]
+    gyldig_fra: '2026-08-01'


### PR DESCRIPTION
## Summary
- Adds Høland og Setskog Elverk AS's (HSEV) new tariff period effective 2026-08-01, closing out the previous 2025-07-01 period.
- Sources:
  - https://hsev.no/nettleie
  - https://hsev.no/uploads/2026-07-06-HSEV-nettleie-privatkunder-2026-08-01-1.pdf

Closes #392

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/holandogsetskogelverk.yml` passes
- [x] `scripts/prissignal.py` picks up the new tariffer for dates after 2026-08-01