### PR TITLE
Update elinett.yml with new prices from 2026-08-01

### DIFF
--- a/tariffer/elinett.yml
+++ b/tariffer/elinett.yml
@@ -5,7 +5,8 @@ gln:
 kilder:
   - 'https://www.elinett.no/kunde/nettleie-2'
   - 'https://www.elinett.no/kunde/nettleie-2/nettleie'
-sist_oppdatert: '2025-10-22'
+  - 'https://www.elinett.no/news/nettleien-oeker-fra-1-august-2026'
+sist_oppdatert: '2026-08-18'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -79,3 +80,40 @@ tariffer:
           pris: 22.64
           dager: [virkedag]
     gyldig_fra: '2025-08-01'
+    gyldig_til: '2026-08-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 2700
+        - terskel: 2
+          pris: 3360
+        - terskel: 5
+          pris: 4020
+        - terskel: 10
+          pris: 6600
+        - terskel: 15
+          pris: 7980
+        - terskel: 20
+          pris: 9300
+        - terskel: 25
+          pris: 13260
+        - terskel: 50
+          pris: 14580
+        - terskel: 75
+          pris: 15900
+        - terskel: 100
+          pris: 19860
+    energiledd:
+      grunnpris: 17.5
+      unntak:
+        - navn: Virkedag
+          timer: 6-21
+          pris: 25.5
+          dager: [virkedag]
+    gyldig_fra: '2026-08-01'


### PR DESCRIPTION
## Summary
- Adds Elinett AS's new tariff period effective 2026-08-01, closing out the previous 2025-08-01 period.
- Sources:
  - https://www.elinett.no/news/nettleien-oeker-fra-1-august-2026
  - https://www.elinett.no/kunde/nettleie-2/nettleie

Closes #393

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/elinett.yml` passes
- [x] `scripts/prissignal.py` picks up the new tariffer for dates after 2026-08-01