### PR TITLE
Update elvenett.yml with new prices from 2026-09-01

### DIFF
--- a/tariffer/elvenett.yml
+++ b/tariffer/elvenett.yml
@@ -2,10 +2,10 @@
 netteier: 'Elvenett AS'
 gln:
   - '7080005052917'
-sist_oppdatert: '2025-10-22'
+sist_oppdatert: '2026-08-23'
 kilder:
   - 'https://www.elvenett.no/priser-og-avtaler/'
-  - 'https://www.elvenett.no/media/guapqy0g/nye-priser-privat-01042025_nye-trinn.pdf'
+  - 'https://www.elvenett.no/media/bupn32os/nye-priser-privat-2026_nye-nettleiepriser-1_09_26.pdf'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -71,3 +71,39 @@ tariffer:
           timer: 6-21
           pris: 20
     gyldig_fra: '2025-04-01'
+    gyldig_til: '2026-09-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 1536
+        - terskel: 2
+          pris: 2232
+        - terskel: 5
+          pris: 3180
+        - terskel: 10
+          pris: 4764
+        - terskel: 15
+          pris: 6120
+        - terskel: 20
+          pris: 7704
+        - terskel: 25
+          pris: 10872
+        - terskel: 50
+          pris: 14508
+        - terskel: 75
+          pris: 18180
+        - terskel: 100
+          pris: 21840
+    energiledd:
+      grunnpris: 5
+      unntak:
+        - navn: Dag
+          timer: 6-22
+          pris: 20
+    gyldig_fra: '2026-09-01'


### PR DESCRIPTION
## Summary
- Adds Elvenett's new tariff period effective 2026-09-01 (husholdning/fritid/liten_næring): energiledd day rate 6-22 now 20 øre/kWh, night 5 øre/kWh; kapasitetsledd tiers below 10 kW reduced, 10 kW+ unchanged.
- Sources:
  - https://www.elvenett.no/aktuelt/nye-nettleiepriser-fra-01-september-2026/ (announcement)
  - https://www.elvenett.no/media/bupn32os/nye-priser-privat-2026_nye-nettleiepriser-1_09_26.pdf (privat/mindre næring price sheet)

Closes #391

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/elvenett.yml` passes
- [x] `scripts/prissignal.py` picks up the new tariff for dates after 2026-09-01