### PR TITLE
Update soraurdalenergi.yml with new prices from 2026-09-01

### DIFF
--- a/tariffer/soraurdalenergi.yml
+++ b/tariffer/soraurdalenergi.yml
@@ -37,6 +37,7 @@ tariffer:
   - kundegrupper:
       - husholdning
       - fritid
+      - liten_næring
     fastledd:
       metode: MND_MAX
       terskel_inkludert: false

--- a/tariffer/soraurdalenergi.yml
+++ b/tariffer/soraurdalenergi.yml
@@ -4,8 +4,8 @@ gln:
   - '7080005046459'
 kilder:
   - 'https://sae.no/tariffer'
-  - 'https://sae.no/uploads/Kundeinformasjon/2024_08_Kundeinformasjon_tariffer.pdf'
-sist_oppdatert: '2024-11-24'
+  - 'https://sae.no/uploads/Kundeinformasjon/2026_09_Kundeinformasjon_tariffer.pdf'
+sist_oppdatert: '2026-08-23'
 tariffer:
   - kundegrupper:
       - husholdning
@@ -33,3 +33,30 @@ tariffer:
           pris: 25.52
           måneder: [januar, februar, mars, oktober, november, desember]
     gyldig_fra: '2024-09-01'
+    gyldig_til: '2026-09-01'
+  - kundegrupper:
+      - husholdning
+      - fritid
+    fastledd:
+      metode: MND_MAX
+      terskel_inkludert: false
+      terskler:
+        - terskel: 0
+          pris: 5400
+        - terskel: 5
+          pris: 6240
+        - terskel: 8
+          pris: 7440
+        - terskel: 15
+          pris: 8640
+        - terskel: 30
+          pris: 9720
+        - terskel: 50
+          pris: 13200
+    energiledd:
+      grunnpris: 25.52
+      unntak:
+        - navn: Vinter
+          pris: 29.52
+          måneder: [januar, februar, mars, oktober, november, desember]
+    gyldig_fra: '2026-09-01'


### PR DESCRIPTION
## Summary
- Adds Sør Aurdal Energi's new tariff period effective 2026-09-01 (husholdning/fritid): energiledd raised by 4 øre/kWh ekskl. avgifter to 25.52 sommer / 29.52 vinter (announced as a 5 øre/kWh incl. mva increase). Fastledd unchanged.
- Sources:
  - https://sae.no/tariffer
  - https://sae.no/uploads/Kundeinformasjon/2026_09_Kundeinformasjon_tariffer.pdf

Closes #394

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/soraurdalenergi.yml` passes
- [x] `scripts/prissignal.py` picks up the new tariff for dates after 2026-09-01