### PR TITLE
Legg til liten_næring-tariff for Etna Nett

### DIFF
--- a/tariffer/etna.yml
+++ b/tariffer/etna.yml
@@ -2,7 +2,7 @@
 netteier: 'Etna Nett AS'
 gln:
   - '7080005046404'
-sist_oppdatert: '2026-04-09'
+sist_oppdatert: '2026-08-23'
 kilder:
   - 'https://etna.no/uploads/Kunde-og-nettleie/Etna-Nett-Nettariff-1-oktober-2025.pdf'
   - 'https://etna.no/om-nettleie'
@@ -93,6 +93,41 @@ tariffer:
     gyldig_fra: '2025-10-01'
     gyldig_til: '2026-05-01'
   - kundegrupper:
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 3063.36
+        - terskel: 2
+          pris: 4595.52
+        - terskel: 5
+          pris: 5987.52
+        - terskel: 10
+          pris: 7380.48
+        - terskel: 15
+          pris: 9746.88
+        - terskel: 20
+          pris: 12184.32
+        - terskel: 25
+          pris: 18102
+        - terskel: 50
+          pris: 27849.6
+        - terskel: 75
+          pris: 34812
+        - terskel: 100
+          pris: 41774.4
+    energiledd:
+      grunnpris: 17.59
+      unntak:
+        - navn: Dag
+          timer: 6-21
+          pris: 24.55
+          dager: [virkedag]
+    gyldig_fra: '2025-10-01'
+    gyldig_til: '2026-05-01'
+  - kundegrupper:
       - husholdning
       - fritid
     fastledd:
@@ -111,6 +146,40 @@ tariffer:
           pris: 9747.6
         - terskel: 20
           pris: 12184.8
+    energiledd:
+      grunnpris: 18.59
+      unntak:
+        - navn: Dag
+          timer: 6-21
+          pris: 25.55
+          dager: [virkedag]
+    gyldig_fra: '2026-05-01'
+  - kundegrupper:
+      - liten_næring
+    fastledd:
+      metode: TRE_DØGNMAX_MND
+      terskel_inkludert: true
+      terskler:
+        - terskel: 0
+          pris: 3360
+        - terskel: 2
+          pris: 5040
+        - terskel: 5
+          pris: 5986.8
+        - terskel: 10
+          pris: 7380
+        - terskel: 15
+          pris: 9747.6
+        - terskel: 20
+          pris: 12184.8
+        - terskel: 25
+          pris: 18102
+        - terskel: 50
+          pris: 27849.6
+        - terskel: 75
+          pris: 34812
+        - terskel: 100
+          pris: 41774.4
     energiledd:
       grunnpris: 18.59
       unntak:


### PR DESCRIPTION
## Summary
- Adds the missing liten_næring (næring < 100 000 kWh/år) tariff for Etna Nett, for the two periods already covered by husholdning/fritid (2025-10-01 → 2026-05-01, and 2026-05-01 →). Overview showed Etna had no liten_næring data at all despite the source already listed in `kilder:` publishing it.
- Fastledd tiers up to 25 kW match husholdning's fastledd exactly (same base rate); tiers 25-100 kW are næring-only, taken directly from the sources. For 2025-10-01, Etna's PDF folds the 800 kr/år Enova-påslag into the fastledd figures — backed it out (÷12 per month) before storing, per this repo's ekskl.-avgifter convention.
- Sources:
  - https://etna.no/uploads/Kunde-og-nettleie/Etna-Nett-Nettariff-1-oktober-2025.pdf (næring table, page 2)
  - https://etna.no/uploads/Kunde-og-nettleie/Etna-Nett-Nettariff-1-mai-2026.pdf (næring table, page 3)

Note: while cross-checking, the existing husholdning entry for 2026-05-01 has terskel 5 (5-10 kW) = 5976, which doesn't reconstruct from the source's stated 498,90 kr/mnd eks. mva (× 12 = 5986.8). 
## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/etna.yml` passes