### PR TITLE
Fix etna.yml: correct 5-10 kW fastledd for 2026-05-01 period

### DIFF
--- a/tariffer/etna.yml
+++ b/tariffer/etna.yml
@@ -104,7 +104,7 @@ tariffer:
         - terskel: 2
           pris: 5040
         - terskel: 5
-          pris: 5976
+          pris: 5986.8
         - terskel: 10
           pris: 7380
         - terskel: 15


### PR DESCRIPTION
## Summary
- Corrects `tariffer/etna.yml`'s husholdning/fritid fastledd for the 5-10 kW tier (2026-05-01 period): 5976 → 5986.8 kr/år. The source states 498,90 kr/mnd eks. mva (× 12 = 5986.80); the stored value doesn't reproduce from any published figure and appears to be a data-entry typo introduced in #333.
- Source:
  - https://etna.no/uploads/Kunde-og-nettleie/Etna-Nett-Nettariff-1-mai-2026.pdf

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/etna.yml` passes