### PR TITLE
Fix area-nettinord.yml: correct top three fastledd tiers for 2026

### DIFF
--- a/tariffer/area-nettinord.yml
+++ b/tariffer/area-nettinord.yml
@@ -59,11 +59,11 @@ tariffer:
         - terskel: 10
           pris: 10080
         - terskel: 15
-          pris: 12140
+          pris: 11340
         - terskel: 20
-          pris: 14030
+          pris: 13230
         - terskel: 25
-          pris: 17180
+          pris: 16380
     energiledd:
       grunnpris: 26.89
       unntak:


### PR DESCRIPTION
## Summary
- Corrects husholdning/liten_næring fastledd for the 2026-01-01 period in `tariffer/area-nettinord.yml`: 15-20 kW 12140→11340, 20-25 kW 14030→13230, 25-100 kW 17180→16380 (kr/år). These three tiers had been left at the næringskunder (<100 000 kWh) table's values instead of husholdning's own — the 2026 price sheet's "Husholdning - Område 1" table gives 11340/13230/16380, matching area-luostejok.yml and area-lega.yml which already had this right.
- Source: https://www.area.no/getfile.php/132156-1766066155/Filer/20251218_Tariffer%202026.pdf (already in `kilder`)

Closes #386

## Test plan
- [x] `cue vet --schema "#Selskap" tariff.cue tariffer/area-nettinord.yml` passes